### PR TITLE
Nav toggler init

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,15 +1,4 @@
 /*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, or any plugin's
- * vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
- *
  *= require_tree .
  *= require_self
  */

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -2,9 +2,14 @@
   visibility: visible;
 }
 
-.nav_rotate {
+.nav_rotate_open {
   transform: rotate(90deg);
-  transition-duration: .5;
+  transition-duration: .2s;
+}
+
+.nav_rotate_close {
+  transform: rotate(0deg);
+  transition-duration: .2s;
 }
 
 #navContainer {
@@ -37,17 +42,14 @@
     display: flex;
 
     > #navToggler {
-      display: flex;
       justify-content: center;
       align-items: center;
 
     }
     > #navMenu {
-      display: flex;
 
       > a {
         font-family: 'Nova Mono', monospace;
-        font-weight: bold;
         padding: .5rem;
         color: black;
 
@@ -93,13 +95,13 @@
     }
 
     > #navMenu {
-      visibility: hidden;
       display: none;
       flex-direction: column;
       position: absolute;
-      top: auto;
-      right: .5em;
+      top: 10%;
+      right: 10%;
       z-index: 2;
+      box-shadow:0px 0px 3px .1px rgba(0, 0, 0, .2);
 
       background-color: white;
       border: solid #EEE 1px;

--- a/app/javascript/src/_navbar.js
+++ b/app/javascript/src/_navbar.js
@@ -1,17 +1,19 @@
 const navToggleButton = document.getElementById('navToggler');
 
-function toggleMenu(menu) {
-  // if (menu.style.display == '') {
-  //   menu.setAttribute('display', 'flex');
-  // } else {
-  //   menu.setAttribute('display', '');
-  // }
-  console.log(menu);
+function toggleMenu(e, menu) {
+  if (menu.style.display == '') {
+    e.target.classList.add('nav_rotate_open');
+    e.target.classList.remove('nav_rotate_close');
+    menu.style.display = 'flex';
+  } else {
+    e.target.classList.add('nav_rotate_close');
+    e.target.classList.remove('nav_rotate_open');
+    menu.style.display = '';
+  }
 };
-
 
 const navMenu = document.getElementById('navMenu');
 
-navToggleButton.addEventListener('click', () => {
-  toggleMenu(navMenu);
+navToggleButton.addEventListener('click', (e) => {
+  toggleMenu(e, navMenu);
 });

--- a/app/javascript/src/_navbar.js
+++ b/app/javascript/src/_navbar.js
@@ -1,18 +1,17 @@
 const navToggleButton = document.getElementById('navToggler');
+
+function toggleMenu(menu) {
+  // if (menu.style.display == '') {
+  //   menu.setAttribute('display', 'flex');
+  // } else {
+  //   menu.setAttribute('display', '');
+  // }
+  console.log(menu);
+};
+
+
 const navMenu = document.getElementById('navMenu');
-let isOpen = false;
-
-function navToggle(isOpen) {
-
-  if (isOpen == false) {
-    isOpen = true;
-  } else {
-    isOpen = false;
-  }
-
-  console.log(isOpen);
-}
 
 navToggleButton.addEventListener('click', () => {
-  navToggle();
+  toggleMenu(navMenu);
 });

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -5,7 +5,7 @@
   </div>
   <div id="navRightSideContainer">
     <div id="navToggler">
-      <span id="navMenuToggler"><i class="fa fa-bars"></i></span>
+      <span id="navMenuToggler"><i class="fa fa-bars nav_rotate_close"></i></span>
     </div>
     <div id="navMenu">
       <a href="#" class="menu-item">BLOG</a>


### PR DESCRIPTION
This set of code is used to:
    * Hide navbar menu on mobile devices in Portrait mode (screens with width as large as 550px)
    * enable navigation menu to appear and disappear (popup) when user clicks on Hamburger nav icon
    * to rotate the hamburger icon and rotate it back to its original position depending on whether the menu is open or not.